### PR TITLE
Fix override of TryMakePreToilReservations.

### DIFF
--- a/Source/JobDriver_DrillUp.cs
+++ b/Source/JobDriver_DrillUp.cs
@@ -13,7 +13,7 @@ namespace MountainMiner
         private const int TICKS = GenDate.TicksPerDay;
         private Building_MountainDrill Comp => (Building_MountainDrill)this.TargetA.Thing;
 
-        public override bool TryMakePreToilReservations() => this.pawn.Reserve(target: this.TargetA, job: this.job);
+        public override bool TryMakePreToilReservations(bool errorOnFailed) => this.pawn.Reserve(target: this.TargetA, job: this.job, errorOnFailed: errorOnFailed);
 
         protected override IEnumerable<Toil> MakeNewToils()
         {


### PR DESCRIPTION
Dear, erdelf.

Fixed because override of JobDriver_DrillUp.TryMakePreToilReservations was wrong.
It seems to be working properly on my Mac.

It is my first time to do Modding, so please check it.

MountainMiner is one of my favorite Mod in RimWorld.

Regards,
Sakumi